### PR TITLE
Separate argument_spec and README validation

### DIFF
--- a/ansibledocsmith/src/ansible_docsmith/cli.py
+++ b/ansibledocsmith/src/ansible_docsmith/cli.py
@@ -193,6 +193,14 @@ def validate(
     verbose: bool = typer.Option(
         False, "-v", "--verbose", help="Enable verbose logging"
     ),
+    validate_readme: bool = typer.Option(
+        True, "--readme/--no-readme", help="Validate README documentation"
+    ),
+    validate_argument_specs: bool = typer.Option(
+        True,
+        "--argument_specs/--no-argument-specs",
+        help="Validate argument_specs file",
+    ),
 ):
     """Validate argument_specs.yml structure and content."""
 
@@ -213,7 +221,11 @@ def validate(
         processor = RoleProcessor(format_type=format_type, role_path=role_path)
 
         # Validate the role
-        role_data = processor.validate_role(role_path)
+        role_data = processor.validate_role(
+            role_path,
+            validate_readme=validate_readme,
+            validate_argument_specs=validate_argument_specs,
+        )
 
         # Display validation results
         _display_validation_results(role_data)

--- a/ansibledocsmith/src/ansible_docsmith/core/processor.py
+++ b/ansibledocsmith/src/ansible_docsmith/core/processor.py
@@ -98,7 +98,12 @@ class RoleProcessor:
                 format_type=self.format_type, toc_bullet_style=self.toc_bullet_style
             )
 
-    def validate_role(self, role_path: Path) -> dict:
+    def validate_role(
+        self,
+        role_path: Path,
+        validate_readme: bool = True,
+        validate_argument_specs: bool = True,
+    ) -> dict:
         """
         Validate role structure and return metadata with further check results
         (like consistency, unknown keys).
@@ -113,32 +118,34 @@ class RoleProcessor:
             role_data.setdefault("warnings", [])
             role_data.setdefault("notices", [])
 
-            # Add consistency validation
-            errors, warnings, notices = self._validate_defaults_consistency(
-                role_path, role_data["specs"], role_data["spec_file"]
-            )
-            role_data["errors"].extend(errors)
-            role_data["warnings"].extend(warnings)
-            role_data["notices"].extend(notices)
+            if validate_argument_specs:
+                # Add consistency validation
+                errors, warnings, notices = self._validate_defaults_consistency(
+                    role_path, role_data["specs"], role_data["spec_file"]
+                )
+                role_data["errors"].extend(errors)
+                role_data["warnings"].extend(warnings)
+                role_data["notices"].extend(notices)
 
-            # Add unknown keys validation
-            warnings = self._validate_unknown_keys(role_data["spec_file"])
-            role_data["warnings"].extend(warnings)
+                # Add unknown keys validation
+                warnings = self._validate_unknown_keys(role_data["spec_file"])
+                role_data["warnings"].extend(warnings)
 
-            # Add mutually exclusive keys validation
-            exclusive_errors = self._validate_mutually_exclusive_keys(
-                role_data["spec_file"]
-            )
-            role_data["errors"].extend(exclusive_errors)
+                # Add mutually exclusive keys validation
+                exclusive_errors = self._validate_mutually_exclusive_keys(
+                    role_data["spec_file"]
+                )
+                role_data["errors"].extend(exclusive_errors)
 
-            # Add README marker validation
-            readme_errors = self._validate_readme_markers(role_path)
-            role_data["errors"].extend(readme_errors)
+            if validate_readme:
+                # Add README marker validation
+                readme_errors = self._validate_readme_markers(role_path)
+                role_data["errors"].extend(readme_errors)
 
-            # Add TOC marker validation
-            toc_errors, toc_notices = self._validate_readme_toc_markers(role_path)
-            role_data["errors"].extend(toc_errors)
-            role_data["notices"].extend(toc_notices)
+                # Add TOC marker validation
+                toc_errors, toc_notices = self._validate_readme_toc_markers(role_path)
+                role_data["errors"].extend(toc_errors)
+                role_data["notices"].extend(toc_notices)
 
             # Fail validation if errors found
             if role_data.get("errors"):

--- a/ansibledocsmith/src/ansible_docsmith/core/processor.py
+++ b/ansibledocsmith/src/ansible_docsmith/core/processor.py
@@ -175,7 +175,7 @@ class RoleProcessor:
 
         try:
             # Validate and parse role
-            role_data = self.validate_role(role_path)
+            role_data = self.validate_role(role_path, validate_readme=generate_readme)
             specs = role_data["specs"]
             role_name = role_data["role_name"]
 

--- a/ansibledocsmith/tests/unit/test_processor.py
+++ b/ansibledocsmith/tests/unit/test_processor.py
@@ -189,6 +189,55 @@ class TestRoleProcessor:
         )
         assert "Default value mismatch for variable 'install_force'" in warning_messages
 
+    def test_validate_only_readme(self):
+        """
+        Test only validating the README file, not the argument_specs file.
+        """
+        processor = RoleProcessor()
+
+        from pathlib import Path
+
+        fixture_path = Path("tests/fixtures/example-role-mismatch-spec-defaults")
+
+        result = processor.validate_role(
+            fixture_path,
+            validate_readme=True,
+            validate_argument_specs=False,
+        )
+
+        # example-role-mismatch-spec-defaults warnings should not be present because we are skipping argument_spec validation
+        warning_messages = "\n".join(result["warnings"])
+        assert (
+            "Default value mismatch for variable 'main_state'" not in warning_messages
+        )
+        assert "argument_specs.yml defines 'present'" not in warning_messages
+        assert "defaults/main.yml defines 'absent'" not in warning_messages
+        assert (
+            "Default value mismatch for variable 'install_version'"
+            not in warning_messages
+        )
+        assert (
+            "Default value mismatch for variable 'install_force'"
+            not in warning_messages
+        )
+
+    def test_validate_only_argument_specs(self):
+        """
+        Test only validating the argument_specs file, not the README file.
+        """
+        processor = RoleProcessor()
+
+        from pathlib import Path
+
+        fixture_path = Path("tests/fixtures/example-role-missing-readme-markers")
+
+        # Should not throw ValidationError even though there are errors in the README file, because we are not validating the README
+        processor.validate_role(
+            fixture_path,
+            validate_readme=False,
+            validate_argument_specs=True,
+        )
+
     def test_validate_defaults_value_mismatch_detection(self, temp_dir):
         """Test detection of default value mismatches between specs and defaults."""
         processor = RoleProcessor()

--- a/ansibledocsmith/tests/unit/test_processor.py
+++ b/ansibledocsmith/tests/unit/test_processor.py
@@ -69,6 +69,26 @@ class TestRoleProcessor:
         defaults_ops = [op for op in result.operations if "main.yml" in str(op[0])]
         assert len(defaults_ops) == 1
 
+    def test_process_role_defaults_only_bad_readme(self):
+        """Test processing role with defaults update only with an invalid README."""
+        processor = RoleProcessor(dry_run=True)
+
+        from pathlib import Path
+        fixture_path = Path("tests/fixtures/example-role-missing-readme-markers")
+        result = processor.process_role(
+            fixture_path,
+            generate_readme=False,
+            update_defaults=True,
+        )
+
+        assert len(result.operations) >= 1
+        # We should have no errors even though the README is invalid because we are only updating defaults
+        assert len(result.errors) == 0
+        # Check that defaults operation exists
+        defaults_ops = [op for op in result.operations if "main.yml" in str(op[0])]
+        assert len(defaults_ops) == 1
+
+
     def test_process_role_both_operations(self, sample_role_with_specs_and_defaults):
         """Test processing role with both README and defaults."""
         processor = RoleProcessor(dry_run=True)


### PR DESCRIPTION
closes: https://github.com/foundata/ansible-docsmith/issues/19 (my own issue)

Adds `--no-readme` and  `--no-argument-specs` to the `ansible-docsmith validate` command.

also added two new tests covering this functionality, `test_validate_only_readme` and `test_validate_only_argument_specs` respectively.

edit:

also fixed `ansible-docsmith generate --no-readme` when an invalid README exists

regression test named `test_process_role_defaults_only_bad_readme`

### before
<img width="1486" height="239" alt="image" src="https://github.com/user-attachments/assets/594d7dfb-99b5-47df-998b-787cca71222f" />

### after
<img width="769" height="239" alt="image" src="https://github.com/user-attachments/assets/0ce714b8-d7d5-49cf-b750-b48419d1e9ae" />
